### PR TITLE
Update 'pid' to 'Pid'

### DIFF
--- a/content/42_30_os.md
+++ b/content/42_30_os.md
@@ -66,7 +66,7 @@ func main() {
 		fmt.Printf("Error %v starting process!", err) //
 		os.Exit(1)
 	}
-	fmt.Printf("The process id is %v", pid)
+	fmt.Printf("The process id is %v", Pid)
 }
 ```
 


### PR DESCRIPTION
os.StartProcess return 'Pid' , so there should be 'Pid' in fmt.Printf()